### PR TITLE
fix: don't write file when dependencies empty

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -136,9 +136,11 @@ export default function esbuildPluginLicense(options: Options = {}): Plugin {
             licenseText: await getLicenseText(pkg!.path)
           })
         }
-        fs.writeFileSync(outputFile, thirdPartyLicenseResult, {
-          encoding: 'utf-8'
-        })
+        if (thirdPartyLicenseResult) {
+          fs.writeFileSync(outputFile, thirdPartyLicenseResult, {
+            encoding: 'utf-8'
+          })
+        }
       })
     }
   }


### PR DESCRIPTION
Hi, friendly ping @upupming
If there are no dependencies, no need to generate files.
If you accept the PR, can you bump the version?