### PR TITLE
fix: add types to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {
+    "types": "./dist/index.d.ts",
     "require": "./dist/index.js",
     "import": "./dist/index.mjs"
   },


### PR DESCRIPTION
`exports` needs to include a reference to the types, because typescript's modern `moduleResolution` settings don't respect the top-level `types` field.